### PR TITLE
Resolve license warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # elm-brunch
-Brunch plugin to compile Elm code
+[Brunch](http://brunch.io) plugin to compile Elm code
 
 # Install Elm
 [Elm instalation instructions](http://elm-lang.org/Install.elm)
@@ -9,17 +9,18 @@ Update the "source-directories" property in the elm-package.json file if you wan
 Then configure elm-brunch:
 
 ```
-  // Configure your plugins
+  // Configure your plugins in brunch-config.js (or .coffee)
     plugins: {
       ...
 
       elmBrunch: {
-        // Set to path where elm-package.json is located, defaults to project root
+        // Set to path where elm-package.json is located, defaults to project root (optional)
+        // if your elm files are not in /app then make sure to configure paths.watched in main brunch config
         elmFolder: 'path/to/elm-files',
-        // Set to the elm file(s) containing your "main" function 
-        // `elm make` handles all elm dependencies
+        // Set to the elm file(s) containing your "main" function
+        // `elm make` handles all elm dependencies (required)
         mainModules: ['source/path/YourMainModule.elm'],
-        // Defaults to 'js/' folder in paths.public
+        // Defaults to 'js/' folder in paths.public (optional)
         outputFolder: 'some/path/'
       }
    }
@@ -30,3 +31,9 @@ The output filename is the lowercase version of the main module name:
 ```
 YourMainModule.elm => outputFolder/yourmainmodule.elm
 ```
+
+# Examples
+The following repos are examples of elm-brunch configuration:
+- https://github.com/joedski/brunch-with-elm/blob/master/brunch-config.coffee
+- https://github.com/madsflensted/dots/blob/master/brunch-config.js
+- https://github.com/ivanoats/Bingo/blob/master/brunch-config.js

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "brunch.io"
   ],
   "author": "Mads Flensted-Urech",
-  "license": "The MIT License (MIT)",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/madsflensted/elm-brunch/issues"
   },


### PR DESCRIPTION
Warning was "should be a valid SPDX license expression" on node 4.1.1 and npm 2.14.4
Copied simplified text from https://spdx.org/licenses/

(I know this is nit-picking, sorry. Stand by for more significant commits, I promise!) 
