### PR TITLE
Skip compilation for non-main on init.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@
       elm_config.mainModules = (config.plugins.elmBrunch || {}).mainModules;
       elm_config.elmFolder = (config.plugins.elmBrunch || {}).elmFolder || null;
       this.elm_config = elm_config;
+      this.skipedOnInit = {}
     }
 
     ElmCompiler.prototype.compile = function(data, file, callback) {
@@ -25,6 +26,12 @@
       var file_is_module_index = modules.indexOf(file);
       if (file_is_module_index >= 0) {
         modules = [modules[file_is_module_index]];
+      } else {
+        if (this.skipedOnInit[file]){
+        } else {
+          this.skipedOnInit[file] = true;
+          return callback(null, null);
+        }
       }
       var outputFolder = this.elm_config.outputFolder;
       var elmFolder = this.elm_config.elmFolder;


### PR DESCRIPTION
I use this plugin for bigger project. I got pretty annoyed with fact that my main module will get compiled dozen of times because there are dozen of  `.elm` files.

With this change when brunch initial encounters `.elm` file that is not main module it skips it, but if file is changed later on, main modules get recompiled.
