### PR TITLE
Fix end of input issues on compile

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,9 +62,14 @@
     info += ', to ' + outputFile;
     console.log(info);
 
-    childProcess.exec('elm make --yes --output ' + outputFile + ' ' + srcFile, {cwd: elmFolder}, function (error, stdout, stderr){
-      return callback(error, error ? stderr : '');
-    });
+    var command = 'elm make --yes --output ' + outputFile + ' ' + srcFile;
+
+    try {
+      childProcess.execSync(command, { cwd: elmFolder })
+      callback(null, "");
+    } catch (error) {
+      callback(error, "");
+    }
   };
 
 }).call(this);

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -6,7 +6,7 @@ var chai = require('chai')
 chai.use(sinonChai);
 
 var ElmCompiler = require('../index')
-  , exec;
+  , execSync;
 
 describe('ElmCompiler', function (){
   var elmCompiler, baseConfig = {
@@ -137,7 +137,7 @@ describe('ElmCompiler', function (){
       , sampleConfig;
 
     beforeEach(function () {
-      exec = sinon.stub(childProcess, 'exec');
+      execSync = sinon.stub(childProcess, 'execSync');
 
       sampleConfig = JSON.parse(JSON.stringify(baseConfig));
       sampleConfig.plugins.elmBrunch.outputFolder = 'test/output/folder';
@@ -145,7 +145,7 @@ describe('ElmCompiler', function (){
     });
 
     afterEach(function () {
-      exec.restore();
+      execSync.restore();
     });
 
     describe('when an elm folder has not been given', function () {
@@ -164,7 +164,7 @@ describe('ElmCompiler', function (){
           expect(error).to.not.be.ok;
         });
         expected = 'elm make --yes --output test/output/folder/test.js Test.elm';
-        expect(childProcess.exec).to.have.been.calledWith(expected, {cwd: null});
+        expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: null});
       });
     });
 
@@ -184,7 +184,7 @@ describe('ElmCompiler', function (){
           expect(error).to.not.be.ok;
         });
         expected = 'elm make --yes --output test/output/folder/test.js Test.elm';
-        expect(childProcess.exec).to.have.been.calledWith(expected, {cwd: 'test/elm/folder'});
+        expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: 'test/elm/folder'});
       });
 
       it('normalises the brunch file path to the elmFolder path', function () {
@@ -193,7 +193,7 @@ describe('ElmCompiler', function (){
           expect(error).to.not.be.ok;
         });
         expected = 'elm make --yes --output test/output/folder/test.js Test.elm';
-        expect(childProcess.exec).to.have.been.calledWith(expected, {cwd: 'test/elm/folder'});
+        expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: 'test/elm/folder'});
       });
 
     });
@@ -212,7 +212,7 @@ describe('ElmCompiler', function (){
             expect(data).to.equal('');
           });
           expected = '';
-          expect(childProcess.exec).to.not.have.been.called;
+          expect(childProcess.execSync).to.not.have.been.called;
         });
 
         it('should compile main modules', function () {
@@ -221,7 +221,7 @@ describe('ElmCompiler', function (){
             expect(error).to.not.be.ok;
           });
           expected = 'elm make --yes --output test/output/folder/test.js Test.elm';
-          expect(childProcess.exec).to.have.been.calledWith(expected, {cwd: null});
+          expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: null});
         });
       });
 
@@ -238,7 +238,7 @@ describe('ElmCompiler', function (){
             expect(error).to.not.be.ok;
           });
           expected = 'elm make --yes --output test/output/folder/test.js Test.elm';
-          expect(childProcess.exec).to.have.been.calledWith(expected, {cwd: null});
+          expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: null});
         });
       });
     });


### PR DESCRIPTION
Seems related to https://github.com/madsflensted/elm-brunch/issues/6.

Fixes errors like "mitlist.js failed. Line 6563: Unexpected end of input".

I looked at a few different elm plugins and many of them seemed to run compilation synchronously. It seems to work well for elm-brunch too.
