### PR TITLE
Handle dependencies of main modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,17 @@ Then configure elm-brunch:
         // Set to path where elm-package.json is located, defaults to project root (optional)
         // if your elm files are not in /app then make sure to configure paths.watched in main brunch config
         elmFolder: 'path/to/elm-files',
+
         // Set to the elm file(s) containing your "main" function
         // `elm make` handles all elm dependencies (required)
         // relative to `elmFolder`
         mainModules: ['source/path/YourMainModule.elm'],
+
+        // Alternatively you can specify main modules and dependencies
+        mainModules: {
+          'source/path/YourMainModule.elm': [ 'source/path/Dependency.elm' ]
+        },
+
         // Defaults to 'js/' folder in paths.public (optional)
         outputFolder: 'some/path/'
       }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,14 @@ YourMainModule.elm => outputFolder/yourmainmodule.elm
 ```
 
 # Examples
+
 The following repos are examples of elm-brunch configuration:
 - https://github.com/joedski/brunch-with-elm/blob/master/brunch-config.coffee
 - https://github.com/madsflensted/dots/blob/master/brunch-config.js
 - https://github.com/ivanoats/Bingo/blob/master/brunch-config.js
+
+# Running tests for this plugin
+```
+npm install
+npm test
+```

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@
       return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
     }
 
-    function buildModuleInfo(config, inFile) {
+    function findModuleToCompile(config, inFile) {
       var file = inFile;
       var elmFolder = config.elmFolder;
 
@@ -34,30 +34,21 @@
       var modules = config.mainModules || [file];
       var mainModuleIndex = modules.indexOf(file);
 
-      if (mainModuleIndex >= 0) {
-        return { path: modules[mainModuleIndex], isMainModule: true };
-      }
-      else {
-        return { path: modules[0], isMainModule: false };
-      }
+      return modules[mainModuleIndex];
     }
 
     ElmCompiler.prototype.compile = function(data, inFile, callback) {
-      var moduleInfo = buildModuleInfo(this.elm_config, inFile);
+      var modulePath = findModuleToCompile(this.elm_config, inFile);
 
-      if (!moduleInfo.isMainModule && !this.skipedOnInit[inFile]) {
-        this.skipedOnInit[inFile] = true;
+      if (!modulePath) {
         return callback(null, '');
       }
 
-      var modules = [ moduleInfo.path ];
       var outputFolder = this.elm_config.outputFolder;
       var elmFolder = this.elm_config.elmFolder;
+      var outputFileName = path.basename(modulePath, '.elm').toLowerCase() + '.js';
 
-      return modules.forEach(function(src) {
-        var outputFileName = path.basename(src, '.elm').toLowerCase() + '.js';
-        return elmCompile(src, elmFolder, path.join(outputFolder, outputFileName), callback);
-      });
+      return elmCompile(modulePath, elmFolder, path.join(outputFolder, outputFileName), callback);
     };
 
     return ElmCompiler;

--- a/index.js
+++ b/index.js
@@ -34,21 +34,22 @@
       var modules = config.mainModules || [file];
       var mainModuleIndex = modules.indexOf(file);
 
-      return modules[mainModuleIndex];
+      return { mainModulePath: modules[mainModuleIndex], dependencyPaths: [] }
     }
 
     ElmCompiler.prototype.compile = function(data, inFile, callback) {
-      var modulePath = findModuleToCompile(this.elm_config, inFile);
+      var info = findModuleToCompile(this.elm_config, inFile);
 
-      if (!modulePath) {
+      if (!info.mainModulePath) {
         return callback(null, '');
       }
 
       var outputFolder = this.elm_config.outputFolder;
       var elmFolder = this.elm_config.elmFolder;
-      var outputFileName = path.basename(modulePath, '.elm').toLowerCase() + '.js';
+      var outputFileName = path.basename(info.mainModulePath, '.elm').toLowerCase() + '.js';
+      var elmSourceFiles = [ info.mainModulePath ].concat(info.dependencyPaths).join(" ")
 
-      return elmCompile(modulePath, elmFolder, path.join(outputFolder, outputFileName), callback);
+      return elmCompile(elmSourceFiles, elmFolder, path.join(outputFolder, outputFileName), callback);
     };
 
     return ElmCompiler;

--- a/index.js
+++ b/index.js
@@ -2,14 +2,11 @@
   var ElmCompiler, elmCompile, childProcess, path;
 
   childProcess = require('child_process');
-
   path = require('path');
 
   module.exports = ElmCompiler = (function() {
     ElmCompiler.prototype.brunchPlugin = true;
-
     ElmCompiler.prototype.type = 'javascript';
-
     ElmCompiler.prototype.extension = 'elm';
 
     function ElmCompiler(config) {
@@ -17,6 +14,7 @@
       elm_config.outputFolder = (config.plugins.elmBrunch || {}).outputFolder || path.join(config.paths.public, 'js');
       elm_config.mainModules = (config.plugins.elmBrunch || {}).mainModules;
       elm_config.elmFolder = (config.plugins.elmBrunch || {}).elmFolder || null;
+
       this.elm_config = elm_config;
       this.skipedOnInit = {}
     }
@@ -26,23 +24,25 @@
     }
 
     ElmCompiler.prototype.compile = function(data, inFile, callback) {
-      var elmFolder = this.elm_config.elmFolder;
       var file = inFile;
+      var elmFolder = this.elm_config.elmFolder;
+
       if (elmFolder) {
         file = inFile.replace(new RegExp('^' + escapeRegExp(elmFolder) + '[/\\\\]?'), '');
       }
+
       var modules = this.elm_config.mainModules || [file];
       var file_is_module_index = modules.indexOf(file);
+
       if (file_is_module_index >= 0) {
         modules = [modules[file_is_module_index]];
-      } else {
-        if (this.skipedOnInit[file]){
-        } else {
-          this.skipedOnInit[file] = true;
-          return callback(null, '');
-        }
+      } else if (!this.skipedOnInit[file]) {
+        this.skipedOnInit[file] = true;
+        return callback(null, '');
       }
+
       var outputFolder = this.elm_config.outputFolder;
+
       return modules.forEach(function(src) {
         var moduleName;
         moduleName = path.basename(src, '.elm').toLowerCase();
@@ -51,15 +51,17 @@
     };
 
     return ElmCompiler;
-
   })();
 
   elmCompile = function(srcFile, elmFolder, outputFile, callback) {
     var info = 'Elm compile: ' + srcFile;
+
     if (elmFolder) {
       info += ', in ' + elmFolder;
     }
+
     info += ', to ' + outputFile;
+
     console.log(info);
 
     var command = 'elm make --yes --output ' + outputFile + ' ' + srcFile;
@@ -71,5 +73,4 @@
       callback(error, "");
     }
   };
-
 }).call(this);

--- a/index.js
+++ b/index.js
@@ -44,9 +44,8 @@
       var outputFolder = this.elm_config.outputFolder;
 
       return modules.forEach(function(src) {
-        var moduleName;
-        moduleName = path.basename(src, '.elm').toLowerCase();
-        return elmCompile(src, elmFolder, path.join(outputFolder, moduleName + '.js'), callback);
+        var outputFileName = path.basename(src, '.elm').toLowerCase() + '.js';
+        return elmCompile(src, elmFolder, path.join(outputFolder, outputFileName), callback);
       });
     };
 

--- a/index.js
+++ b/index.js
@@ -37,8 +37,7 @@
 
       if(config.mainModules instanceof Array) {
         modules = config.mainModules;
-      }
-      else if (config.mainModules) {
+      } else if (config.mainModules) {
         // If the current file is a dependency, find the mainModule it corresponds to
         // so we can build that instead since you can't build dependencies in isolation.
         for(mainModulePath in config.mainModules) {
@@ -51,8 +50,7 @@
 
         dependencyPaths = config.mainModules[file] || [];
         modules = Object.keys(config.mainModules);
-      }
-      else {
+      } else {
         modules = [file];
       }
 

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -234,7 +234,7 @@ describe('ElmCompiler', function (){
           });
 
           expected = 'elm make --yes --output test/output/folder/test.js Test.elm Dep1.elm Dep2.elm';
-          expect(childProcess.exec).to.have.been.calledWith(expected, {cwd: null});
+          expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: null});
         });
 
         it('should compile a main module when a dependency is given', function () {
@@ -249,13 +249,13 @@ describe('ElmCompiler', function (){
           elmCompiler.compile(content, 'Dep2.elm', function(error) {
             expect(error).to.not.be.ok;
           });
-          expect(childProcess.exec).not.to.have.been.called
+          expect(childProcess.execSync).not.to.have.been.called
 
           elmCompiler.compile(content, 'Dep2.elm', function(error) {
             expect(error).to.not.be.ok;
           });
           expected = 'elm make --yes --output test/output/folder/test.js Test.elm Dep1.elm Dep2.elm';
-          expect(childProcess.exec).to.have.been.calledWith(expected, {cwd: null});
+          expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: null});
         });
       });
 

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -156,11 +156,11 @@ describe('ElmCompiler', function (){
 
       it('shells out to the `elm make` command with a null cwd', function () {
         var content = '';
-        elmCompiler.compile(content, 'File.elm', function(error, data) {
+        elmCompiler.compile(content, 'Test.elm', function(error, data) {
           expect(error).to.not.be.ok;
           expect(data).to.equal('');
         });
-        elmCompiler.compile(content, 'File.elm', function(error) {
+        elmCompiler.compile(content, 'Test.elm', function(error) {
           expect(error).to.not.be.ok;
         });
         expected = 'elm make --yes --output test/output/folder/test.js Test.elm';
@@ -177,10 +177,10 @@ describe('ElmCompiler', function (){
 
       it('shells out to the `elm make` command with the specified elm folder as the cwd', function () {
         var content = '';
-        elmCompiler.compile(content, 'File.elm', function(error) {
+        elmCompiler.compile(content, 'Test.elm', function(error) {
           expect(error).to.not.be.ok;
         });
-        elmCompiler.compile(content, 'File.elm', function(error) {
+        elmCompiler.compile(content, 'Test.elm', function(error) {
           expect(error).to.not.be.ok;
         });
         expected = 'elm make --yes --output test/output/folder/test.js Test.elm';


### PR DESCRIPTION
This adds a feature to define dependencies of a main module which will be compiled at the same time as the main module.

If either the main module or the dependencies are changed, the entire set is compiled.

Essentially this allows you to split an .elm file into multiple files and still have the compilation work.

What do you think? Anything I missed, or anything I should change?
