### PR TITLE
manage others elm-make parameters can be useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,17 @@ Then configure elm-brunch:
         // Set to path where elm-package.json is located, defaults to project root (optional)
         // if your elm files are not in /app then make sure to configure paths.watched in main brunch config
         elmFolder: 'path/to/elm-files',
+        
         // Set to the elm file(s) containing your "main" function
         // `elm make` handles all elm dependencies (required)
         // relative to `elmFolder`
         mainModules: ['source/path/YourMainModule.elm'],
+        
         // Defaults to 'js/' folder in paths.public (optional)
-        outputFolder: 'some/path/'
+        outputFolder: 'some/path/',
+        
+        // optional: add some parameters that are passed to elm-make
+        makeParameters : ['--warn']
       }
    }
 
@@ -35,7 +40,7 @@ Then configure elm-brunch:
 
 The output filename is the lowercase version of the main module name:
 ```
-YourMainModule.elm => outputFolder/yourmainmodule.elm
+YourMainModule.elm => outputFolder/yourmainmodule.js
 ```
 
 # Examples

--- a/index.js
+++ b/index.js
@@ -17,8 +17,9 @@
       elm_config.outputFolder = (config.plugins.elmBrunch || {}).outputFolder || path.join(config.paths.public, 'js');
       elm_config.mainModules = (config.plugins.elmBrunch || {}).mainModules;
       elm_config.elmFolder = (config.plugins.elmBrunch || {}).elmFolder || null;
+      elm_config.makeParameters = (config.plugins.elmBrunch || {}).makeParameters || [];
       this.elm_config = elm_config;
-      this.skipedOnInit = {}
+      this.skipedOnInit = {};
     }
 
     function escapeRegExp(str) {
@@ -43,10 +44,14 @@
         }
       }
       var outputFolder = this.elm_config.outputFolder;
+      const makeParameters = this.elm_config.makeParameters;
       return modules.forEach(function(src) {
         var moduleName;
         moduleName = path.basename(src, '.elm').toLowerCase();
-        return elmCompile(src, elmFolder, path.join(outputFolder, moduleName + '.js'), callback);
+        return elmCompile ( src, elmFolder
+                          , path.join(outputFolder, moduleName + '.js')
+                          , makeParameters
+                          , callback );
       });
     };
 
@@ -54,7 +59,7 @@
 
   })();
 
-  elmCompile = function(srcFile, elmFolder, outputFile, callback) {
+  elmCompile = function(srcFile, elmFolder, outputFile, makeParameters, callback) {
     var info = 'Elm compile: ' + srcFile;
     if (elmFolder) {
       info += ', in ' + elmFolder;
@@ -62,10 +67,15 @@
     info += ', to ' + outputFile;
     console.log(info);
 
-    var command = 'elm make --yes --output ' + outputFile + ' ' + srcFile;
+    const params = ['--yes']  //  Reply 'yes' to all automated prompts
+                  .concat(makeParameters) // other options from brunch-config.js
+                  .concat(['--output', outputFile , srcFile ]);
+
+    var command = 'elm make ' + params.join(' ');
+
 
     try {
-      childProcess.execSync(command, { cwd: elmFolder })
+      childProcess.execSync(command, { cwd: elmFolder });
       callback(null, "");
     } catch (error) {
       callback(error, "");

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -130,7 +130,35 @@ describe('ElmCompiler', function (){
         });
       });
     });
+
+
+    describe('makeParameters', function () {
+      describe('when no makeParameters are not specified', function () {
+        beforeEach(function () {
+          elmCompiler = new ElmCompiler(baseConfig);
+        });
+
+        it('defaults to an empty list', function () {
+          expect(elmCompiler.elm_config.makeParameters).to.be.empty;
+        });
+      });
+
+      describe('when some makeParameters are specified', function () {
+        let makeParameters = ['--warn'];
+        beforeEach(function () {
+          config = JSON.parse(JSON.stringify(baseConfig));
+          config.plugins.elmBrunch.makeParameters = makeParameters;
+          elmCompiler = new ElmCompiler(config);
+        });
+
+        it('uses the specified makeParameters', function () {
+          expect(elmCompiler.elm_config.makeParameters).to.equal(makeParameters);
+        });
+      });
+    });
   });
+
+
 
   describe('compiling Elm', function () {
     var childProcess = require('child_process')


### PR DESCRIPTION
Hi, 
I recently discovered your plugin and I have to say that it worked beautifully.

I'm a newbie in elm and I often find useful the compiler warnings.
So this to manage `--warn` and possibly others compiler params.
