### PR TITLE
consoleErrors option to see compilation errors in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Then configure elm-brunch:
         // If specified, all mainModules will be compiled to a single file (optional and merged with outputFolder)
         outputFile: 'elm.js',
 
+        // In case of compilation errors resulting js will contain error messages (default is false)
+        consoleErrors: true,
+
         // optional: add some parameters that are passed to elm-make
         makeParameters : ['--warn']
       }


### PR DESCRIPTION
I've been using elm-brunch with phoenix, and even though the framework nicely reloads page on changes, in case of compilation errors, the old version is loaded and there isn't any clue in the browser window that something went wrong. So I needed to see both browser window and terminal to see what syntax error did I make this time.

With this change all compilation errors are visible directly in the browser window thanks to console.error. Not sure if the option naming is good, and also I'm not much of a node coder so if something can be done better, let me know.

If you don't think such change belongs to elm-brunch that's cool too, just let me know and I will stick to my fork, for me it speeds up development a lot.

edit: and I guess I forgot about adding some tests, I'll wait with them until the info if you want such feature at all
