### PR TITLE
Make compilation in onCompile hook instead of compile method

### DIFF
--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -30,6 +30,10 @@ describe('ElmCompiler', function (){
     it('has a #compile method', function () {
       expect(elmCompiler.compile).to.be.an.instanceof(Function);
     });
+
+    it('has a #onCompile method', function () {
+      expect(elmCompiler.onCompile).to.be.an.instanceof(Function);
+    });
   });
 
   describe('elm config', function () {
@@ -184,13 +188,10 @@ describe('ElmCompiler', function (){
 
       it('shells out to the `elm-make` command with a null cwd', function () {
         var content = '';
-        elmCompiler.compile(content, 'File.elm', function(error, data) {
-          expect(error).to.not.be.ok;
-          expect(data).to.equal('');
-        });
-        elmCompiler.compile(content, 'File.elm', function(error) {
-          expect(error).to.not.be.ok;
-        });
+        elmCompiler.compile(null, null, function(){});
+        elmCompiler.onCompile({sourceFiles: [{path: 'File.elm'}]}, []);
+        elmCompiler.compile(null, null, function(){});
+        elmCompiler.onCompile({sourceFiles: [{path: 'File.elm'}]}, []);
         expected = 'elm-make --yes --output test/output/folder/test.js Test.elm';
         expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: null});
       });
@@ -205,21 +206,18 @@ describe('ElmCompiler', function (){
 
       it('shells out to the `elm-make` command with the specified elm folder as the cwd', function () {
         var content = '';
-        elmCompiler.compile(content, 'File.elm', function(error) {
-          expect(error).to.not.be.ok;
-        });
-        elmCompiler.compile(content, 'File.elm', function(error) {
-          expect(error).to.not.be.ok;
-        });
+        elmCompiler.compile(null, null, function(){});
+        elmCompiler.onCompile({sourceFiles: [{path: 'File.elm'}]}, []);
+        elmCompiler.compile(null, null, function(){});
+        elmCompiler.onCompile({sourceFiles: [{path: 'File.elm'}]}, []);
         expected = 'elm-make --yes --output test/output/folder/test.js Test.elm';
         expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: 'test/elm/folder'});
       });
 
       it('normalises the brunch file path to the elmFolder path', function () {
         var content = '';
-        elmCompiler.compile(content, 'test/elm/folder/Test.elm', function(error) {
-          expect(error).to.not.be.ok;
-        });
+        elmCompiler.compile(null, null, function(){});
+        elmCompiler.onCompile({sourceFiles: [{path: 'test/elm/folder/Test.elm'}]}, []);
         expected = 'elm-make --yes --output test/output/folder/test.js Test.elm';
         expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: 'test/elm/folder'});
       });
@@ -235,19 +233,16 @@ describe('ElmCompiler', function (){
 
         it('should skip non main modules', function () {
           var content = '';
-          elmCompiler.compile(content, 'File.elm', function(error, data) {
-            expect(error).to.not.be.ok;
-            expect(data).to.equal('');
-          });
+          elmCompiler.compile(null, null, function(){});
+          elmCompiler.onCompile({sourceFiles: [{path: 'File.elm'}]}, []);
           expected = '';
           expect(childProcess.execSync).to.not.have.been.called;
         });
 
         it('should compile main modules', function () {
           var content = '';
-          elmCompiler.compile(content, 'Test.elm', function(error) {
-            expect(error).to.not.be.ok;
-          });
+          elmCompiler.compile(null, null, function(){});
+          elmCompiler.onCompile({sourceFiles: [{path: 'Test.elm'}]}, []);
           expected = 'elm-make --yes --output test/output/folder/test.js Test.elm';
           expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: null});
         });
@@ -262,9 +257,8 @@ describe('ElmCompiler', function (){
 
         it('should compile all modules', function () {
           var content = '';
-          elmCompiler.compile(content, 'Test.elm', function(error) {
-            expect(error).to.not.be.ok;
-          });
+          elmCompiler.compile(null, null, function(){});
+          elmCompiler.onCompile({sourceFiles: [{path: 'Test.elm'}]}, []);
           expected = 'elm-make --yes --output test/output/folder/test.js Test.elm';
           expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: null});
         });
@@ -280,9 +274,8 @@ describe('ElmCompiler', function (){
         });
         it('should compile all modules into a single file', function () {
           var content = '';
-          elmCompiler.compile(content, 'Test1.elm', function(error) {
-            expect(error).to.not.be.ok;
-          });
+          elmCompiler.compile(null, null, function(){});
+          elmCompiler.onCompile({sourceFiles: [{path: 'Test1.elm'}]}, []);
           expected = 'elm-make --yes --output test/output/folder/test.js Test1.elm Test2.elm';
           expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: null});
         });


### PR DESCRIPTION
There were some reports about brunch missing changes in elm files after compilation error occurred. Here's the original [StackOverflow question](http://stackoverflow.com/questions/40822312/elm-brunch-watch-is-missing-some-of-my-elm-file-changes/40895350#40895350). 

As I've mentioned on the StackOverflow
> This is both brunch and elm-brunch issue. Brunch plugins are designed to compile each file separately on change. elm-brunch, however, runs elm-make for elm modules instead. That's why brunch cache is not being updated properly, causing redundant error messages.

Running the compilation in the `onCompile` hook instead of the `compile` method is more suitable in this case.