### PR TITLE
Don't crash Brunch process when Elm compilation fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,12 @@
       const command = executable + ' ' + params.join(' ');
 
 
-      childProcess.execSync(command, { cwd: elmFolder });
+      try {
+        childProcess.execSync(command, { cwd: elmFolder });
+      } catch (error) {
+        // we don't want Elm compilation error to crash the whole Brunch process
+      }
+
       this.compiledOnCurrentStep[originSrcFile] = true;
     };
 


### PR DESCRIPTION
Currently `brunch watch` process crashes whenever there is a compilation error in Elm code. This is an attempt to fix the issue which works for me currently.