### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ paths: {
         elmFolder: 'path/to/elm-files',
 
         // (optional) Defaults to 'js/' folder in paths.public
+        // relative to `elmFolder`
         outputFolder: 'some/path/',
 
         // (optional) If specified, all mainModules will be compiled to a single file 


### PR DESCRIPTION
Specify that the `outputFolder` path is relative to the specified `elmFolder` path
For example, if the `elmFolder` is `web/elm` and the `outputFolder` is `js`, the eventual `outputFolder`will be the `web/elm/js` folder.

This is not clear in the README and I was confused the first time I read the README instructions