### PR TITLE
Allow mainModules to keep their own elm-stuff folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ paths: {
         //            handles all elm dependencies relative to `elmFolder`
         mainModules: ['source/path/YourMainModule.elm'],
 
-        // (optional) Set to keep an independant elm-stuff folder per mainModule. If 
+        // (optional) Set to keep an independent elm-stuff folder per mainModule. If 
         //            mainModules is an array, then the 'source/path' of each mainModule 
         //            will be appended to your elm-folder, allowing each subfolder to keep their
         //            own set of elm dependencies.
-        independantModules: true,
+        independentModules: true,
 
         // (optional) Set to path where `elm-make` is located, relative to `elmFolder`
         executablePath: '../../node_modules/elm/binwrappers',

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ paths: {
         //            handles all elm dependencies relative to `elmFolder`
         mainModules: ['source/path/YourMainModule.elm'],
 
-        // (optional) If mainModules is an array, then the 'source/path' of each mainModule 
+        // (optional) Set to keep an independant elm-stuff folder per mainModule. If 
+        //            mainModules is an array, then the 'source/path' of each mainModule 
         //            will be appended to your elm-folder, allowing each subfolder to keep their
-        //            own set of elm dependencies 
+        //            own set of elm dependencies.
         independantModules: true,
 
         // (optional) Set to path where `elm-make` is located, relative to `elmFolder`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ paths: {
         //            handles all elm dependencies relative to `elmFolder`
         mainModules: ['source/path/YourMainModule.elm'],
 
+        // (optional) If mainModules is an array, then the 'source/path' of each mainModule 
+        //            will be appended to your elm-folder, allowing each subfolder to keep their
+        //            own set of elm dependencies 
+        independantModules: true,
+
         // (optional) Set to path where `elm-make` is located, relative to `elmFolder`
         executablePath: '../../node_modules/elm/binwrappers',
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@
       elm_config.outputFolder = (config.plugins.elmBrunch || {}).outputFolder || path.join(config.paths.public, 'js');
       elm_config.outputFile = (config.plugins.elmBrunch || {}).outputFile || null;
       elm_config.mainModules = (config.plugins.elmBrunch || {}).mainModules;
+      elm_config.independantModules = (config.plugins.elmBrunch || {}).independantModules || null;
       elm_config.elmFolder = (config.plugins.elmBrunch || {}).elmFolder || null;
       elm_config.makeParameters = (config.plugins.elmBrunch || {}).makeParameters || [];
       this.elm_config = elm_config;
@@ -48,14 +49,26 @@
       }
       var executablePath = this.elm_config.executablePath;
       var outputFolder = this.elm_config.outputFolder;
+      var independantModules = this.elm_config.independantModules;
       var outputFile = this.elm_config.outputFile;
       const makeParameters = this.elm_config.makeParameters;
       if (outputFile === null) {
         return compileModules.forEach(function(src) {
           var moduleName;
           moduleName = path.basename(src, '.elm').toLowerCase();
+          if(independantModules){
+            var src_path_length = src.split("/").length;
+            if(src_path_length > 1){
+                moduleName = path.dirname(src).replace('/','_') + '_' + moduleName;
+                outputFolder = "../".repeat(src_path_length - 1) + outputFolder;
+                if(elmFolder == null)
+                    elmFolder = path.dirname(src);
+                else
+                    elmFolder = elmFolder + "/" + path.dirname(src);
+            }
+          }
           return elmCompile ( executablePath
-                            , src
+                            , path.basename(src)
                             , elmFolder
                             , path.join(outputFolder, moduleName + '.js')
                             , makeParameters

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@
       elm_config.outputFolder = (config.plugins.elmBrunch || {}).outputFolder || path.join(config.paths.public, 'js');
       elm_config.outputFile = (config.plugins.elmBrunch || {}).outputFile || null;
       elm_config.mainModules = (config.plugins.elmBrunch || {}).mainModules;
-      elm_config.independantModules = (config.plugins.elmBrunch || {}).independantModules || null;
+      elm_config.independentModules = (config.plugins.elmBrunch || {}).independentModules || null;
       elm_config.elmFolder = (config.plugins.elmBrunch || {}).elmFolder || null;
       elm_config.makeParameters = (config.plugins.elmBrunch || {}).makeParameters || [];
       this.elm_config = elm_config;
@@ -49,14 +49,14 @@
       }
       var executablePath = this.elm_config.executablePath;
       var outputFolder = this.elm_config.outputFolder;
-      var independantModules = this.elm_config.independantModules;
+      var independentModules = this.elm_config.independentModules;
       var outputFile = this.elm_config.outputFile;
       const makeParameters = this.elm_config.makeParameters;
       if (outputFile === null) {
         return compileModules.forEach(function(src) {
           var moduleName;
           moduleName = path.basename(src, '.elm').toLowerCase();
-          if(independantModules){
+          if(independentModules){
             var src_path_length = src.split("/").length;
             if(src_path_length > 1){
                 moduleName = path.dirname(src).replace('/','_') + '_' + moduleName;

--- a/index.js
+++ b/index.js
@@ -57,14 +57,14 @@
           var moduleName;
           moduleName = path.basename(src, '.elm').toLowerCase();
           if(independentModules){
-            var src_path_length = src.split("/").length;
+            var src_path_length = src.split(path.sep).length;
             if(src_path_length > 1){
-                moduleName = path.dirname(src).replace('/','_') + '_' + moduleName;
-                outputFolder = "../".repeat(src_path_length - 1) + outputFolder;
+                moduleName = path.dirname(src).replace(path.sep,'_') + '_' + moduleName;
+                outputFolder = ('..' + path.sep).repeat(src_path_length - 1) + outputFolder;
                 if(elmFolder == null)
                     elmFolder = path.dirname(src);
                 else
-                    elmFolder = elmFolder + "/" + path.dirname(src);
+                    elmFolder = elmFolder + path.sep + path.dirname(src);
             }
           }
           return elmCompile ( executablePath

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -95,7 +95,7 @@ describe('ElmCompiler', function (){
         });
       });
 
-      describe('when more than one mainModule is specified, independantModules is true, and each mainModule contains the relative widget path', function () {
+      describe('when more than one mainModule is specified, independentModules is true, and each mainModule contains the relative widget path', function () {
         beforeEach(function () {
           config = JSON.parse(JSON.stringify(baseConfig));
           config.plugins.elmBrunch.mainModules = ['widget1/Test1.elm', 'widget2/Test2.elm']

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -98,7 +98,8 @@ describe('ElmCompiler', function (){
       describe('when more than one mainModule is specified, independentModules is true, and each mainModule contains the relative widget path', function () {
         beforeEach(function () {
           config = JSON.parse(JSON.stringify(baseConfig));
-          config.plugins.elmBrunch.mainModules = ['widget1/Test1.elm', 'widget2/Test2.elm']
+          config.plugins.elmBrunch.mainModules = ['widget1/Test1.elm', 'widget2/Test2.elm'];
+          config.plugins.elmBrunch.independentModules = true;
           elmCompiler = new ElmCompiler(config);
         });
 
@@ -106,6 +107,8 @@ describe('ElmCompiler', function (){
           expect(elmCompiler.elm_config.mainModules.length).to.equal(2);
           expect(elmCompiler.elm_config.mainModules).to.include('widget1/Test1.elm');
           expect(elmCompiler.elm_config.mainModules).to.include('widget2/Test2.elm');
+          expect(elmCompiler.elm_config.independentModules).to.equal(true);
+
         });
       });
     });

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -94,6 +94,20 @@ describe('ElmCompiler', function (){
           expect(elmCompiler.elm_config.mainModules).to.include('Test2.elm');
         });
       });
+
+      describe('when more than one mainModule is specified, independantModules is true, and each mainModule contains the relative widget path', function () {
+        beforeEach(function () {
+          config = JSON.parse(JSON.stringify(baseConfig));
+          config.plugins.elmBrunch.mainModules = ['widget1/Test1.elm', 'widget2/Test2.elm']
+          elmCompiler = new ElmCompiler(config);
+        });
+
+        it('provides the specified mainModule with widget folder', function () {
+          expect(elmCompiler.elm_config.mainModules.length).to.equal(2);
+          expect(elmCompiler.elm_config.mainModules).to.include('widget1/Test1.elm');
+          expect(elmCompiler.elm_config.mainModules).to.include('widget2/Test2.elm');
+        });
+      });
     });
 
     describe('elmFolder', function () {

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -301,6 +301,58 @@ describe('ElmCompiler', function (){
           expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: null});
         });
       });
+      describe('when independentModules is true, and elmFolder exists', function () {
+        beforeEach(function () {
+          config = JSON.parse(JSON.stringify(baseConfig));
+          config.plugins.elmBrunch.elmFolder = 'elm';
+          config.plugins.elmBrunch.outputFolder = 'test/output/folder';
+          config.plugins.elmBrunch.mainModules = ['widget1/Test1.elm'];
+          config.plugins.elmBrunch.independentModules = true;
+          elmCompiler = new ElmCompiler(config);
+        });
+        it('shells out to the `elm-make` command with the mainModule path as the cwd, and output folder to a level higher', function () {
+          var content = '';
+          elmCompiler.compile(content, 'elm/widget1/Test1.elm', function(error) {
+            expect(error).to.not.be.ok;
+          });
+          expected = 'elm-make --yes --output ../test/output/folder/widget1_test1.js Test1.elm';
+          expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: 'elm/widget1'});
+        });
+      });
+      describe('when independentModules is true, and elmFolder is null', function () {
+        beforeEach(function () {
+          config = JSON.parse(JSON.stringify(baseConfig));
+          config.plugins.elmBrunch.outputFolder = 'test/output/folder';
+          config.plugins.elmBrunch.mainModules = ['widget1/Test1.elm'];
+          config.plugins.elmBrunch.independentModules = true;
+          elmCompiler = new ElmCompiler(config);
+        });
+        it('shells out to the `elm-make` command with the mainModule path as the cwd, and output folder to a level higher', function () {
+          var content = '';
+          elmCompiler.compile(content, 'widget1/Test1.elm', function(error) {
+            expect(error).to.not.be.ok;
+          });
+          expected = 'elm-make --yes --output ../test/output/folder/widget1_test1.js Test1.elm';
+          expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: 'widget1'});
+        });
+      });
+      describe('when independentModules is true, and mainModule is 2 folders deep', function () {
+        beforeEach(function () {
+          config = JSON.parse(JSON.stringify(baseConfig));
+          config.plugins.elmBrunch.outputFolder = 'test/output/folder';
+          config.plugins.elmBrunch.mainModules = ['category/widget/Test1.elm'];
+          config.plugins.elmBrunch.independentModules = true;
+          elmCompiler = new ElmCompiler(config);
+        });
+        it('shells out to the `elm-make` command with the mainModule path as the cwd, and output folder to 2 levels higher', function () {
+          var content = '';
+          elmCompiler.compile(content, 'category/widget/Test1.elm', function(error) {
+            expect(error).to.not.be.ok;
+          });
+          expected = 'elm-make --yes --output ../../test/output/folder/category_widget_test1.js Test1.elm';
+          expect(childProcess.execSync).to.have.been.calledWith(expected, {cwd: 'category/widget'});
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
I've added an 'independantModules' configuration option which allows us to keep separate 'elm-stuff' folders at the 'source/path' of our mainModules.

**Reason for this feature:** I use elm-brunch along with Elixir's Phoenix Web Framework, where I create an 'elm' folder under assets and would like to keep independent elm modules as widgets to use on different pages in my web app. I would like to be able to update one widget without affecting another in the future.
